### PR TITLE
Fix import for Python 3.10

### DIFF
--- a/stagger/frames.py
+++ b/stagger/frames.py
@@ -41,6 +41,11 @@ from warnings import warn
 from stagger.errors import *
 from stagger.specs import *
 
+try:
+    from collections import Container
+except ImportError:
+    from collections.abc import Container
+
 class Frame(metaclass=abc.ABCMeta):
     _framespec = tuple()
     _version = tuple()
@@ -114,7 +119,7 @@ class Frame(metaclass=abc.ABCMeta):
         "Returns true if this frame is in any of the specified versions of ID3."
         for version in versions:
             if (self._version == version
-                or (isinstance(self._version, collections.Container) 
+                or (isinstance(self._version, Container)
                     and version in self._version)):
                 return True
         return False

--- a/stagger/tags.py
+++ b/stagger/tags.py
@@ -219,7 +219,12 @@ class FrameOrder:
         return "<FrameOrder: {0}>".format(", ".join(pair[0] for pair in order))
         
 
-class Tag(collections.MutableMapping, metaclass=abc.ABCMeta):
+try:
+    from collections import MutableMapping
+except ImportError:
+    from collections.abc import MutableMapping
+
+class Tag(MutableMapping, metaclass=abc.ABCMeta):
     known_frames = { }        # Maps known frameids to Frame class objects
 
     frame_order = None        # Initialized by stagger.id3


### PR DESCRIPTION
As of Python 3.10 in collections:

- MutableMapping is now abc.MutableMapping

- Container is now abc.Container

Issue #56